### PR TITLE
(#4) Revert elasticsearch dependency to v15.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-tools",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -731,12 +731,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/elasticsearch": {
-      "version": "5.0.24",
-      "resolved": "https://registry.npmjs.org/@types/elasticsearch/-/elasticsearch-5.0.24.tgz",
-      "integrity": "sha512-QRpGleGwKv70hEcdklBh3HiLZ3OHPp40nRiVfhLk9wlQ4+V//SX+n90uIHN/mfKz828bjSSAxSG/kDUEp4Yp8Q==",
-      "dev": true
-    },
     "@types/graceful-fs": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
@@ -781,9 +775,9 @@
       }
     },
     "@types/node": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.4.tgz",
-      "integrity": "sha512-YMLlzdeNnAyLrQew39IFRkMacAR5BqKGIEei9ZjdHsIZtv+ZWKYTu1i7QJhetxQ9ReXx8w5f+cixdHZG3zgMQA==",
+      "version": "14.14.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
+      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1603,9 +1597,9 @@
       }
     },
     "elasticsearch": {
-      "version": "16.7.2",
-      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-16.7.2.tgz",
-      "integrity": "sha512-1ZLKZlG2ABfYVBX2d7/JgxOsKJrM5Yu62GvshWu7ZSvhxPomCN4Gas90DS51yYI56JolY0XGhyiRlUhLhIL05Q==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-15.5.0.tgz",
+      "integrity": "sha512-ZGKKaDkOFAap61ObBNkAxhYXCcAbRfkI4NVoSeLGnTD6/cItvY2j9LII/VV8/zclGe1x5m6DsVp47E4ze4aAeQ==",
       "requires": {
         "agentkeepalive": "^3.4.1",
         "chalk": "^1.0.0",
@@ -3368,9 +3362,9 @@
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-tools",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Node Library of Common Elasticsearch Helper functions used across platforms",
   "main": "index.js",
   "scripts": {
@@ -23,13 +23,12 @@
   },
   "homepage": "https://github.com/NCIOCPL/elastic-tools#readme",
   "dependencies": {
-    "elasticsearch": "^16.7.2",
-    "moment": "^2.22.0"
+    "elasticsearch": "^15.5.0",
+    "moment": "^2.29.1"
   },
   "devDependencies": {
-    "@types/elasticsearch": "^5.0.24",
     "@types/jest": "^26.0.20",
-    "@types/node": "^10.3.4",
+    "@types/node": "^14.14.20",
     "jest": "^26.6.3",
     "nock": "^13.0.5",
     "winston": "^3.3.3",


### PR DESCRIPTION
- Update all other dependencies to current version.
- Remove unused dev dependency on @types/elasticsearch

Closes #4 
